### PR TITLE
Fix printing when a node has only one child

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ var treePrinter = function treePrinter(tree, options) {
 		}
 		// }}}
 
-		if (branch[settings.fields.children] && branch[settings.fields.children].length > 1) {
+		if (branch[settings.fields.children] && branch[settings.fields.children].length >= 1) {
 			out += depthMarker + settings.format[isLast ? 'branchChildrenLast' : 'branchChildren'].replace('{{name}}', name) + settings.format.eol;
 			var newSettings = {};
 			_merge(newSettings, settings);


### PR DESCRIPTION
```js
{
  name: 'Foo',
  children: [
    {name: 'Foo-Foo'}
  ]
}
```